### PR TITLE
fix: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Based on [sensiolabs/security-checker](https://github.com/sensiolabs/security-ch
 
 ## Inputs
 
-### `composer-lock`
+### `composer.lock`
 
-The folder to control. Default `"./composer-lock"`.
+The folder to control. Default `"./composer.lock"`.
 
 ## Example usage
 
@@ -16,5 +16,5 @@ The folder to control. Default `"./composer-lock"`.
 - name: PHP Security Checker
   uses: StephaneBour/actions-php-security-checker@1.1
   with:
-    composer-lock: './composer-lock'
+    composer-lock: './composer.lock'
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The folder to control. Default `"./composer-lock"`.
 
 ```yaml
 - name: PHP Security Checker
-  uses: StephaneBour/actions-php-security-checker@1.0
+  uses: StephaneBour/actions-php-security-checker@1.1
   with:
     composer-lock: './composer-lock'
 ```


### PR DESCRIPTION
If you're using v1.0 of this it will fail like;
```
  Step 6/9 : RUN curl -L https://get.sensiolabs.org/security-checker.phar -o /security-checker
   ---> Running in 4fa19bd6e34f
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
  
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: get.sensiolabs.org
  The command '/bin/sh -c curl -L https://get.sensiolabs.org/security-checker.phar -o /security-checker' returned a non-zero code: 6
```